### PR TITLE
Add Username and Token Properties to correct Authentication Errors

### DIFF
--- a/name_com_dns.py
+++ b/name_com_dns.py
@@ -15,8 +15,10 @@ class NameComDNS:
             raise ValueError('Please specify `domain_name`')
 
         self.domain_name = domain_name
-
         self.base_url = 'https://api.name.com/v4/domains/{0}/records'.format(self.domain_name)
+		
+		self.username = username
+		self.token = token
 
     def list_records(self):
         r = requests.get(self.base_url, auth=(self.username, self.token))


### PR DESCRIPTION
Using this for a client, we received an error that no username / token properties existed in the name_com_dns object. Hence we realized these two constructor params were not being stored in the instance. After correcting this, the authentication hook worked correctly.